### PR TITLE
bump base version of the package to 0.0.2

### DIFF
--- a/projects/yti-common-ui/package.json
+++ b/projects/yti-common-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vrk-yti/yti-common-ui",
   "repository": "git://github.com/VRK-YTI/yti-common-ui.git",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },


### PR DESCRIPTION
Now that the latest changes have been merged to master, and a `0.0.1` version has been published to the github npm registry, we can bump up the base version for future releases.
